### PR TITLE
view post details and tag api/form added

### DIFF
--- a/src/api/commentData.js
+++ b/src/api/commentData.js
@@ -62,4 +62,18 @@ const deleteComment = (id) =>
       .catch(reject);
   });
 
-export { createComment, getComment, updateComment, deleteComment };
+// COMMENTS USING POST ID
+const getCommentsUsingId = (id) =>
+  new Promise((resolve, reject) => {
+    fetch(`${dbURL}/comments?posts=${id}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+      .then((response) => response.json())
+      .then((data) => resolve(Object.values(data)))
+      .catch(reject);
+  });
+
+export { createComment, getComment, updateComment, deleteComment, getCommentsUsingId };

--- a/src/api/postData.js
+++ b/src/api/postData.js
@@ -88,26 +88,6 @@ const deletePost = (id) =>
       .catch(reject);
   });
 
-// GET A SINGLE POST'S COMMENTS
-// const getPostCommemnts = (firebaseKey) =>
-//   new Promise((resolve, reject) => {
-//     fetch(`${endpoint}/posts.json?orderBy="uid"&equalTo="${uid}"`, {
-//       method: 'GET',
-//       headers: {
-//         'Content-Type': 'application/json',
-//       },
-//     })
-//       .then((response) => response.json())
-//       .then((data) => resolve(Object.values(data)))
-//       .catch(reject);
-//   });
+/// SEARCH BAR FOR POSTS BY COUNTRY ///
 
-export {
-  getPosts,
-  getAllPosts,
-  createPost,
-  getSinglePost,
-  deletePost,
-  updatePost,
-  // getPostCommemnts
-};
+export { getPosts, getAllPosts, createPost, getSinglePost, deletePost, updatePost };

--- a/src/api/tagData.js
+++ b/src/api/tagData.js
@@ -1,0 +1,91 @@
+import { clientCredentials } from '../utils/client';
+
+const endpoint = clientCredentials.databaseURL;
+
+// GET ALL TAGS
+const getAllTags = () =>
+  new Promise((resolve, reject) => {
+    fetch(`${endpoint}/tags`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+      .then((response) => response.json())
+      .then((data) => resolve(Object.values(data)))
+      .catch(reject);
+  });
+
+// GET TAGS FROM SINGLE USER
+const getSingleUserTags = (uid) =>
+  new Promise((resolve, reject) => {
+    fetch(`${endpoint}/tags?uid=${uid}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+      .then((response) => response.json())
+      .then((data) => resolve(Object.values(data)))
+      .catch(reject);
+  });
+
+// GET A SINGLE TAG
+const getSingleTag = (id) =>
+  new Promise((resolve, reject) => {
+    fetch(`${endpoint}/tags/${id}.json`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+      .then((response) => response.json())
+      .then((data) => resolve(data))
+      .catch(reject);
+  });
+
+// CREATE TAG
+const createTag = (payload) =>
+  new Promise((resolve, reject) => {
+    fetch(`${endpoint}/tags.json`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    })
+      .then((response) => response.json())
+      .then((data) => resolve(data))
+      .catch(reject);
+  });
+
+// UPDATE TAG
+const updateTag = (payload) =>
+  new Promise((resolve, reject) => {
+    fetch(`${endpoint}/tags/${payload.id}.json`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    })
+      .then((response) => response.json())
+      .then((data) => resolve(data))
+      .catch(reject);
+  });
+
+// DELETE TAG
+const deleteTag = (id) =>
+  new Promise((resolve, reject) => {
+    fetch(`${endpoint}/tags/${id}.json`, {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+      .then((response) => response.json())
+      .then((data) => resolve(data))
+      .catch(reject);
+  });
+
+export { getSingleUserTags, getAllTags, createTag, getSingleTag, deleteTag, updateTag };

--- a/src/api/userData.js
+++ b/src/api/userData.js
@@ -1,0 +1,1 @@
+// FOR USER PROFILE //

--- a/src/app/post/[id]/page.js
+++ b/src/app/post/[id]/page.js
@@ -1,5 +1,83 @@
-import React from 'react';
+'use client';
 
-export default function page() {
-  return <div />;
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { Card, Carousel } from 'react-bootstrap';
+// import Link from "next/link";
+import CommentCard from '../../../components/CommentCard';
+import CommentForm from '../../../components/forms/CommentForm';
+import { getCommentsUsingId } from '../../../api/commentData';
+import { getSinglePost } from '../../../api/postData';
+
+const initialState = {
+  title: '',
+  author: '',
+  category: '',
+  body: '',
+  tags: '',
+};
+export default function ViewPost({ params }) {
+  const { id } = params;
+  const postId = Number(id);
+
+  const [postDetails, setPostDetails] = useState({});
+
+  const [comments, setComments] = useState([]);
+
+  const getThePost = () => {
+    getSinglePost(id).then(setPostDetails);
+  };
+  const getPostComments = () => {
+    getCommentsUsingId(id).then(setComments);
+  };
+
+  useEffect(() => {
+    getThePost();
+    getPostComments();
+  }, [postId, getThePost, getPostComments]);
+
+  return (
+    <div className="mt-5 d-flex flex-wrap">
+      <div className="text-white ms-5 details">
+        <div className="text-white ms-5 details" style={{ width: '400px' }}>
+          <h2>{postDetails.title}</h2>
+          <h3>{postDetails.category}</h3>
+          <p>Post Description: {postDetails.body || ''}</p>
+          <p>Tags: {postDetails.tags?.map((tag, index) => (index === postDetails.tags.length - 1 ? tag.name : `${tag.name}, `))}</p>
+          <div>
+            <p>Comments</p>
+            <Carousel interval={3000} style={{ width: '400px', margin: 'auto' }}>
+              {comments.map((comment) => (
+                <Carousel.Item key={comment.id}>
+                  <CommentCard commentObj={comment} onUpdate={getPostComments} />
+                </Carousel.Item>
+              ))}
+            </Carousel>
+            <Card style={{ width: '400px', margin: '15px', backgroundColor: 'black', padding: '10px' }}>
+              <Card.Body>
+                <CommentForm commentPostId={postId} onSubmit={getCommentsUsingId} />
+              </Card.Body>
+            </Card>{' '}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 }
+
+ViewPost.propTypes = {
+  params: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+  }).isRequired,
+  postDetails: PropTypes.shape({
+    title: PropTypes.string,
+    author: PropTypes.string,
+    category: PropTypes.string,
+    body: PropTypes.string,
+    tags: PropTypes.arrayOf(PropTypes.string),
+  }),
+};
+
+ViewPost.defaultProps = {
+  postDetails: initialState,
+};

--- a/src/app/post/edit/[id]/page.js
+++ b/src/app/post/edit/[id]/page.js
@@ -1,3 +1,21 @@
-export default function EditForm() {
-  return <div />;
+'use client';
+
+import PropTypes from 'prop-types';
+import { useEffect, useState } from 'react';
+import { getSinglePost } from '../../../../api/postData';
+import PostForm from '../../../../components/forms/PostForm';
+
+export default function EditPost({ params }) {
+  const [editItem, setEditItem] = useState({});
+  const { id } = params;
+
+  useEffect(() => {
+    getSinglePost(id).then(setEditItem);
+  }, [id]);
+
+  return <PostForm obj={editItem} />;
 }
+
+EditPost.propTypes = {
+  params: PropTypes.objectOf({}).isRequired,
+};

--- a/src/app/posts/page.js
+++ b/src/app/posts/page.js
@@ -1,5 +1,43 @@
-import React from 'react';
+/* eslint-disable react-hooks/exhaustive-deps */
 
-export default function page() {
-  return <div />;
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { Button } from 'react-bootstrap';
+import { useAuth } from '@/utils/context/authContext';
+import { getPosts } from '../../api/postData';
+import PostCard from '../../components/PostCard';
+
+function Home() {
+  // set a state for posts
+  const [posts, setPosts] = useState([]);
+
+  // get user ID using useAuth Hook
+  const { user } = useAuth();
+
+  // create a function that makes the API call to get all the posts
+  const getAllThePosts = () => {
+    getPosts(user.id).then(setPosts);
+  };
+
+  // make the call to the API to get all the posts on component render
+  useEffect(() => {
+    getAllThePosts();
+  }, []);
+
+  return (
+    <div className="text-center my-4">
+      <Link href="/post/new" passHref>
+        <Button>Create A Post</Button>
+      </Link>
+      <div className="d-flex flex-wrap">
+        {/* map over posts here using PostCard component */}
+        {posts.map((post) => (
+          <PostCard key={post.id} postObj={post} onUpdate={getAllThePosts} />
+        ))}
+      </div>
+    </div>
+  );
 }
+export default Home;

--- a/src/components/CommentCard.js
+++ b/src/components/CommentCard.js
@@ -5,7 +5,7 @@ import { Button, Card } from 'react-bootstrap';
 import deleteComment from '../api/commentData';
 
 export default function CommentCard() {
-// insert obj when applicable
+  // insert obj when applicable
   const removeComment = (remainingComments) => {
     deleteComment().then(() => remainingComments);
     // insert obj when applicable
@@ -32,7 +32,7 @@ export default function CommentCard() {
         <Button variant="danger" type="button" onClick={removeComment}>
           Delete
         </Button>
-        <Card.Text className="mt-1 text-muted">TimeStamp</Card.Text>
+        {/* <Card.Text className="mt-1 text-muted">TimeStamp</Card.Text> */}
       </Card.Body>
     </Card>
   );

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -19,6 +19,9 @@ function PostNavBar() {
             <Link className="nav-link" href="/">
               Home
             </Link>
+            <Link className="nav-link" href="/posts">
+              Posts
+            </Link>
             <RegionDropDown />
             <Link className="nav-link" href="/profile">
               Profile

--- a/src/components/PostCard.js
+++ b/src/components/PostCard.js
@@ -6,6 +6,7 @@ import Button from 'react-bootstrap/Button';
 import Card from 'react-bootstrap/Card';
 import Link from 'next/link';
 import { deletePost } from '../api/postData';
+import { useAuth } from '../utils/context/authContext';
 
 function PostCard({ postObj, onUpdate }) {
   const deleteSinglePost = () => {
@@ -13,6 +14,8 @@ function PostCard({ postObj, onUpdate }) {
       deletePost(postObj.id).then(() => onUpdate());
     }
   };
+
+  const { user } = useAuth;
 
   return (
     <Card
@@ -32,9 +35,14 @@ function PostCard({ postObj, onUpdate }) {
           </Button>
         </Link>
         {/* EDIT POST DETAILS  */}
-        <Link href={`/post/edit/${postObj.id}`} passHref>
-          <Button variant="info">EDIT</Button>
-        </Link>
+
+        {user?.uid === postObj?.author?.uid ? (
+          <Link href={`/post/edit/${postObj.id}`} passHref>
+            <Button variant="success">Edit</Button>
+          </Link>
+        ) : (
+          ''
+        )}
         {/* TEMP DELETE BUTTON */}
         <Button variant="danger" onClick={deleteSinglePost} className="m-2">
           DELETE

--- a/src/components/forms/CommentForm.js
+++ b/src/components/forms/CommentForm.js
@@ -47,9 +47,9 @@ function CommentForm({ obj = intialState }) {
 
   return (
     <Form onSubmit={handleSubmit} className="text-black">
-      <Form.Label className="text-white">Create a Comment</Form.Label>
+      <Form.Label className="text-white">Leave a Comment</Form.Label>
       <Form.Group>
-        <FloatingLabel label="Comment" className="mb-3">
+        <FloatingLabel label="thoughts?" className="mb-3">
           <Form.Control
             placeholder="Comment"
             name="comment"

--- a/src/components/forms/PostForm.js
+++ b/src/components/forms/PostForm.js
@@ -21,7 +21,7 @@ const initialState = {
   country: '',
   region: '',
   image: '',
-  tags: '',
+  tags: [],
 };
 
 function PostForm({ obj }) {
@@ -92,16 +92,6 @@ function PostForm({ obj }) {
         </Form.Select>
       </FloatingLabel>
 
-      {/* BODY INPUT */}
-      <FloatingLabel controlId="floatingInput4" label="Body" className="mb-3">
-        <Form.Control type="text" placeholder="Enter description" name="post_body" value={formInput.body} onChange={handleChange} required />
-      </FloatingLabel>
-
-      {/* CATEGORY INPUT  */}
-      <FloatingLabel controlId="floatingInput5" label="Category" className="mb-3">
-        <Form.Control type="text" placeholder="Enter category" name="category" value={formInput.category} onChange={handleChange} required />
-      </FloatingLabel>
-
       {/* REGION INPUT  */}
       <FloatingLabel controlId="floatingInput6" label="Region" className="mb-3">
         <Form.Select controlId="dropdown2" type="text" placeholder="Enter region" name="region" value={formInput.region} onChange={handleChange} required>
@@ -114,16 +104,31 @@ function PostForm({ obj }) {
         </Form.Select>
       </FloatingLabel>
 
+      {/* BODY INPUT */}
+      <FloatingLabel controlId="floatingInput4" label="Body" className="mb-3">
+        <Form.Control type="text" placeholder="Enter description" name="body" value={formInput.body} onChange={handleChange} required />
+      </FloatingLabel>
+
+      {/* CATEGORY INPUT  */}
+      <FloatingLabel controlId="floatingInput5" label="Category" className="mb-3">
+        <Form.Control type="text" placeholder="Enter category" name="category" value={formInput.category} onChange={handleChange} required />
+      </FloatingLabel>
+
       {/* IMAGE INPUT  */}
-      <FloatingLabel controlId="floatingInput7" label="Author Image" className="mb-3">
+      <FloatingLabel controlId="floatingInput7" label="Post Image" className="mb-3">
         <Form.Control type="url" placeholder="Enter an image url" name="image" value={formInput.image} onChange={handleChange} required />
       </FloatingLabel>
+
+      {/* ///// ADD TAG FEATURE HERE???? ////// */}
+      <Form.Label>
+        <p>Tags</p>
+      </Form.Label>
+      <Form.Control type="name" placeholder="Add Tags" />
+      <Form.Text className="text-muted">Add tags that best fit the content of this post.</Form.Text>
 
       {/* SUBMIT BUTTON */}
       <Button type="submit">{obj.id ? 'Update' : 'Create'} Post</Button>
     </Form>
-
-    /// // ADD TAG FEATURE HERE???? //////
   );
 }
 

--- a/src/components/forms/TagForm.js
+++ b/src/components/forms/TagForm.js
@@ -1,5 +1,78 @@
-import React from 'react';
+import PropTypes from 'prop-types';
+import { useEffect, useState } from 'react';
+import { Button, FloatingLabel, Form } from 'react-bootstrap';
+import { useAuth } from '../../utils/context/authContext';
+import { createTag, getAllTags, updateTag } from '../../api/tagData';
 
-export default function TagForm() {
-  return <div />;
+const initialState = {
+  id: '',
+  name: '',
+};
+
+function TagForm({ obj, onSubmit }) {
+  const [formInput, setFormInput] = useState(initialState);
+  const [tags, setTags] = useState([]);
+  const { user } = useAuth();
+
+  useEffect(() => {
+    if (obj.id) {
+      setFormInput(obj);
+    } else {
+      setFormInput(initialState);
+    }
+  }, [obj]);
+
+  useEffect(() => {
+    getAllTags(setTags);
+  }, []);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormInput((prevState) => ({
+      ...prevState,
+      [name]: value,
+    }));
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (obj.id) {
+      updateTag(formInput).then(onSubmit);
+    } else {
+      const payload = {
+        name: obj.name,
+      };
+      createTag(user.id, payload).then(() => {
+        setFormInput(initialState);
+        onSubmit();
+      });
+    }
+  };
+
+  return (
+    <Form onSubmit={handleSubmit}>
+      <h4 className="text-white mt-5">{obj.id ? 'Update' : 'Add'} Tag</h4>
+      <p>{tags}</p>
+
+      <FloatingLabel controlId="floatingTextarea" label="new tag" className="mb-3">
+        <Form.Control as="textarea" placeholder="Add new tag" style={{ height: '200px', width: '400px' }} name="label" value={formInput.name} onChange={handleChange} required />
+
+        {/* SUBMIT TAG */}
+        <Button type="submit">{obj.id ? 'Update' : 'Add'} Tag</Button>
+      </FloatingLabel>
+    </Form>
+  );
 }
+
+TagForm.propTypes = {
+  obj: PropTypes.shape({
+    id: PropTypes.number,
+    name: PropTypes.string,
+  }),
+  onSubmit: PropTypes.func.isRequired,
+};
+
+TagForm.defaultProps = {
+  obj: initialState,
+};
+export default TagForm;


### PR DESCRIPTION
## Description
View Post page has been added along with api calls and form for tags.

## Related Issue
- [ Tag Form](https://github.com/lndnbrr/destinationguides-frontend/issues/35)
- [Read Single Post](https://github.com/lndnbrr/destinationguides-frontend/issues/27)
- [Create Tags](https://github.com/lndnbrr/destinationguides-frontend/issues/19)
- [Read Tags](https://github.com/lndnbrr/destinationguides-frontend/issues/17)
- [Update Tags](https://github.com/lndnbrr/destinationguides-frontend/issues/21)
- [Delete Tags](https://github.com/lndnbrr/destinationguides-frontend/issues/22)

## Motivation and Context
Tag form needed to add tags to posts. In order to CRUD tags, API calls were created and added to tagsData file.

## How Can This Be Tested?
n/a

## Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ x ] Breaking change (fix or feature that would cause existing functionality to change)
